### PR TITLE
Allow empty paragraphs <p/>

### DIFF
--- a/schema/wmt-schema.rnc
+++ b/schema/wmt-schema.rnc
@@ -3,7 +3,7 @@ Segment = element seg {
   text
 }
 Paragraph = element p {
-  Segment+
+  Segment*
 }
 Source = element src {
   attribute lang { xsd:language },


### PR DESCRIPTION
After this change the XML output that `wrap.py` generates can be validated against the XML schema.