### PR TITLE
Add optional <collection> node to the XML format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .history-*
 __pycache__
+*~
+*.swp
+*.swo

--- a/schema/wmt-schema.rnc
+++ b/schema/wmt-schema.rnc
@@ -1,5 +1,6 @@
 Segment = element seg {
   attribute id { xsd:positiveInteger },
+  attribute type { xsd:string }?,
   text
 }
 Paragraph = element p {

--- a/schema/wmt-schema.rnc
+++ b/schema/wmt-schema.rnc
@@ -28,8 +28,13 @@ Document = element doc {
   Reference*,
   System*
 }
-Dataset = element dataset {
+Collection = element collection {
   attribute id { xsd:string },
   Document+
+}
+Dataset = element dataset {
+  attribute id { xsd:string },
+  Collection*,
+  Document*
 }
 start = Dataset


### PR DESCRIPTION
WMT22 will distribute test sets with multiple domains from 3 shared tasks. We want participants to submit translations of all domains, but the scores in OCELoT should be reported for individual task only. This PR extends the schema with an optional `<collection id="">` node (optional for backward compatibility). It will be used in OCELoT to restrict computation of automatic scores only to segments from one predefined collection. I think no modifications to the `wrap.py`/`unwrap.py` scripts will be needed.