### PR TITLE
Update wmt-schema.rnc to allow for supplemental data

### DIFF
--- a/schema/wmt-schema.rnc
+++ b/schema/wmt-schema.rnc
@@ -21,6 +21,10 @@ System = element hyp {
   attribute system { xsd:string },
   Paragraph+
 }
+Supplement = element Supplement {
+  attribute type { xsd:string },
+  Paragraph+
+}
 Document = element doc {
   attribute id { xsd:string },
   attribute origlang { xsd:language },
@@ -28,7 +32,8 @@ Document = element doc {
   attribute domain { xsd:string }?,
   Source,
   Reference*,
-  System*
+  System*,
+  Supplement*
 }
 Collection = element collection {
   attribute id { xsd:string },


### PR DESCRIPTION
The new field should be general enough so we can adjust it as needed for any different type of additional data.
For this year, we need "clean_sources", but this is likely not going to be used next year